### PR TITLE
Assign the correct parameters

### DIFF
--- a/src/queue/QueueSubjectListener.ts
+++ b/src/queue/QueueSubjectListener.ts
@@ -45,13 +45,13 @@ export class QueueSubjectListener {
   }
 
   listen(params: ReceiveMessageRequest) {
-    const {
-      MaxNumberOfMessages,
-      VisibilityTimeout,
-      WaitTimeSeconds,
-      receiveTimeout,
-    } = Object.assign({}, this.options, params);
-    // const self = this;
+    const MaxNumberOfMessages =
+      params?.MaxNumberOfMessages ?? this.options.maxConcurrentMessage;
+    const VisibilityTimeout =
+      params?.VisibilityTimeout ?? this.options.visibilityTimeout;
+    const WaitTimeSeconds =
+      params?.WaitTimeSeconds ?? this.options.waitTimeSeconds;
+    const receiveTimeout = this.options.receiveTimeout;
 
     let cntInFlight = 0;
 


### PR DESCRIPTION
It seems that the default options are not correctly assigned. It used to be default options like this https://github.com/tibbercom/tibber-aws/blob/3fd8110a086ffab4b574cc08794ccaa5fba3b730/src/queue.js#L133

Currently we do 
```js
const {
      MaxNumberOfMessages,
      VisibilityTimeout,
      WaitTimeSeconds,
      receiveTimeout,
    } = Object.assign({}, this.options, params);
```
But `this.options` does not contain any of those properties. So if a consuming service would configure the queue like this:
```js
    const modellingListener = new QueueSubjectListener(
        dependencies.modellingQueue,
        dependencies.logger, { maxConcurrentMessage: 10, waitTimeSeconds: 10, visibilityTimeout: 140, receiveTimeout }
    );
```
it would ignore the `maxConcurrentMessage`, `waitTimeSeconds` and `visibilityTimeout`