### PR TITLE
chore: remove unused make-synchronous package

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@aws-sdk/client-secrets-manager": "^3.621.0",
     "@aws-sdk/client-sns": "^3.621.0",
     "@aws-sdk/client-sqs": "^3.621.0",
-    "make-synchronous": "^1.0.0",
     "sync-rpc": "^1.3.6"
   },
   "config": {


### PR DESCRIPTION
I ran `yarn why make-synchronous` and the output was that no package depends on it.

```
yarn why v1.22.22
warning ../../package.json: No license field
[1/4] 🤔  Why do we have the module "make-synchronous"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "make-synchronous@1.0.0"
info Has been hoisted to "make-synchronous"
info This module exists because it's specified in "dependencies".
✨  Done in 1.80s.
```