### PR TITLE
Enable renovate for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# Dependabot version updates are disabled (open-pull-requests-limit: 0)
+# Regular dependency updates are handled by Renovate instead
+# Security updates are enabled via "Dependabot security updates" in repo settings
+# "Dependabot alerts" will continue to notify about vulnerabilities
 version: 2
 updates:
   - package-ecosystem: "npm"
@@ -8,5 +12,6 @@ updates:
       prefix: "fix"
       prefix-development: "build"
       include: "scope"
+    open-pull-requests-limit: 0
     allow:
       - dependency-type: "production"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
-  "enabledManagers": ["dockerfile"],
+  "enabledManagers": ["dockerfile", "npm"],
   "packageRules": [
       {
         "pinDigests": true,


### PR DESCRIPTION
- Disable Dependabot version updates
- Keep Dependabot security updates
- Enable Renovate for version updates with clever combining rules
- This repo cant inherit shared Renovate repo config as its public