### PR TITLE
Set default SQS receive_wait_time_seconds to 20 for long polling

### DIFF
--- a/src/queue/QueueSubjectListener.ts
+++ b/src/queue/QueueSubjectListener.ts
@@ -54,7 +54,7 @@ export class QueueSubjectListener {
     logger?: undefined | null | ILogger,
     public options: QueueSubjectListenerOptions = {
       maxConcurrentMessage: 1,
-      waitTimeSeconds: 10,
+      waitTimeSeconds: 20,
       visibilityTimeout: 30,
     }
   ) {

--- a/test/QueueSubjectListener.test.ts
+++ b/test/QueueSubjectListener.test.ts
@@ -228,5 +228,30 @@ describe('QueueSubjectListener', () => {
       expect(queueMock.changeMessageVisibility).toHaveBeenCalledTimes(1);
       expect(retryPolicy).toHaveBeenCalledTimes(1);
     });
+
+    it('should default waitTimeSeconds to 20', async () => {
+      const queueMock = {
+        receiveMessage: jest.fn().mockResolvedValueOnce({
+          Messages: messages,
+        }),
+        deleteMessage: jest.fn(Promise.resolve),
+      } as unknown as Queue;
+
+      const sut = new QueueSubjectListener(queueMock, null);
+      sut.onSubject(
+        'test',
+        jest.fn(() => Promise.resolve())
+      );
+      sut.listen();
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+      sut.stop();
+
+      expect(queueMock.receiveMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          WaitTimeSeconds: 20,
+        })
+      );
+    });
   });
 });


### PR DESCRIPTION
This PR updates the default SQS wait time from 10 seconds to 20 seconds to enable more efficient long polling.

## Changes
- Changed default `waitTimeSeconds` from 10 to 20 in `QueueSubjectListener`
- Added test to verify the default value is 20

## Benefits
- Reduces the number of empty SQS ReceiveMessage requests
- More cost-effective SQS polling
- Follows AWS best practices for long polling (20 seconds is the maximum)