### PR TITLE
configure renovate to treat npm dependency updates as fix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,9 @@
         "description": "AWS SDK client packages",
         "matchManagers": ["npm"],
         "matchPackagePrefixes": ["@aws-sdk/client-"],
-        "groupName": "aws-sdk-clients"
+        "matchDepTypes": ["dependencies"],
+        "groupName": "aws-sdk-clients",
+        "extends": [":semanticCommitTypeAll(fix)"]
       }
   ]
 }


### PR DESCRIPTION
Renovate adds chore in the commit message if it finds at least one commit in the dependency with "chore".  The problem is that semantic-release-bot ignores commits with "chore" because it understands it as updates that shouldn't trigger a release. I disagree if that because changes to software dependencies are still changes to the software. Bumping a dependency version might, for example, fix a bug in the software.

This pull request configures Renovate to rename the commit message for updates in dependencies to "fix: ..." instead of "chore: ..."