### PR TITLE
enable renovate automerge for minor and patch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,12 +17,12 @@
         "matchDepTypes": ["dependencies"],
         "groupName": "aws-sdk-clients",
         "extends": [":semanticCommitTypeAll(fix)"],
-        "autoMerge": true
+        "automerge": true
       },
       {
         "description": "NPM patch and minor updates",
         "matchManagers": ["npm"],
-        "autoMerge": true,
+        "automerge": true,
         "matchUpdateTypes": ["patch", "minor"]
       }
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,14 @@
         "matchPackagePrefixes": ["@aws-sdk/client-"],
         "matchDepTypes": ["dependencies"],
         "groupName": "aws-sdk-clients",
-        "extends": [":semanticCommitTypeAll(fix)"]
+        "extends": [":semanticCommitTypeAll(fix)"],
+        "autoMerge": true
+      },
+      {
+        "description": "NPM patch and minor updates",
+        "matchManagers": ["npm"],
+        "autoMerge": true,
+        "matchUpdateTypes": ["patch", "minor"]
       }
   ]
 }


### PR DESCRIPTION
This pull request changes the Renovate configuration to automatically merge Renovate updates to npm packages with minor or patches. Renovate will only merge the pull request if the CircleCI build job passes.