### PR TITLE
Remove fast-xml-parser resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "node": ">=22.0.0"
   },
   "resolutions": {
-    "fast-xml-parser": "^5.3.8",
     "undici": "^7.24.4",
     "flatted": "^3.4.0"
   },


### PR DESCRIPTION
Remove fast-xml-parser custom resolution pinning it to an old version with vulnerabilities even though the aws sdk packages using it are already updated to use a later fixed one.