### PR TITLE
Pin localstack image to 4.14.0  

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  localstack: localstack/platform@2.1.0
 workflows:
   build_and_deploy:
     jobs:
@@ -21,12 +19,31 @@ jobs:
     working_directory: ~/package
     machine:
       image: ubuntu-2204:2025.09.1
-    environment:
-      IMAGE_NAME: localstack/localstack:4.14
     steps:
       - checkout
-      - localstack/startup:
-        image: localstack/localstack:4.14
+      - run:
+          name: Start LocalStack container
+          command: |
+            docker pull localstack/localstack:4.14
+            docker run -d \
+              --name localstack \
+              -p 4566:4566 \
+              -e AWS_DEFAULT_REGION=eu-west-1 \
+              -e SERVICES=lambda,secretsmanager \
+              localstack/localstack:4.14
+
+            for i in $(seq 1 60); do
+              if curl -s http://localhost:4566/_localstack/health | grep "\"initialized\": true" >/dev/null; then
+                echo "LocalStack is ready"
+                break
+              fi
+              if [ "$i" -eq 60 ]; then
+                echo "LocalStack failed to initialize in time"
+                docker logs localstack
+                exit 1
+              fi
+              sleep 2
+            done
       - run:
           name: Setup Localstack resources
           environment:
@@ -35,9 +52,9 @@ jobs:
             AWS_SECRET_ACCESS_KEY: test
           command: |
             echo "Creating test resources"
-            awslocal secretsmanager create-secret --region $AWS_REGION --name my-secret --secret-string '{"PG_PASSWORD":"stacy"}'
+            aws --endpoint-url=http://localhost:4566 secretsmanager create-secret --region $AWS_REGION --name my-secret --secret-string '{"PG_PASSWORD":"stacy"}'
             cd test/lambda
-            awslocal lambda create-function --region $AWS_REGION --function-name localstack-lambda-url-example --runtime nodejs18.x --zip-file fileb://function.zip --handler index.handler --role arn:aws:iam::000000000000:role/lambda-role
+            aws --endpoint-url=http://localhost:4566 lambda create-function --region $AWS_REGION --function-name localstack-lambda-url-example --runtime nodejs18.x --zip-file fileb://function.zip --handler index.handler --role arn:aws:iam::000000000000:role/lambda-role
             cd ../..
             echo "Done creating test resources"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,8 @@ jobs:
       IMAGE_NAME: localstack/localstack:4.14
     steps:
       - checkout
-      - localstack/startup
+      - localstack/startup:
+        image: localstack/localstack:4.14
       - run:
           name: Setup Localstack resources
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ jobs:
     working_directory: ~/package
     machine:
       image: ubuntu-2204:2025.09.1
+    environment:
+      IMAGE_NAME: localstack/localstack:4.14
     steps:
       - checkout
       - localstack/startup
@@ -36,7 +38,7 @@ jobs:
             cd test/lambda
             awslocal lambda create-function --region $AWS_REGION --function-name localstack-lambda-url-example --runtime nodejs18.x --zip-file fileb://function.zip --handler index.handler --role arn:aws:iam::000000000000:role/lambda-role
             cd ../..
-            echo "Done creating test resources" 
+            echo "Done creating test resources"
       - run:
           name: Test Package
           environment:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -17,7 +17,7 @@ services:
         - LOCALSTACK_ENDPOINT=http://localstack:4566
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_test}"
-    image: localstack/localstack
+    image: localstack/localstack:4.14
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
@@ -45,4 +45,4 @@ services:
         aws --endpoint-url=http://localstack:4566 secretsmanager create-secret --name my-secret --secret-string '{"PG_PASSWORD":"stacy"}'
         cd /app/test/lambda
         aws --endpoint-url=http://localstack:4566 lambda create-function --function-name localstack-lambda-url-example --runtime nodejs18.x --zip-file fileb://function.zip --handler index.handler --role arn:aws:iam::000000000000:role/lambda-role
-        echo "Done creating test resources" 
+        echo "Done creating test resources"


### PR DESCRIPTION
Pin localstack image to 4.14.0 (last free community version) in docker-compose.yml and CircleCI config.

