### PR TITLE
fix OIDC between circleci and npm - PLA-888

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,10 +61,7 @@ jobs:
           name: Deploy Package
           command: |
             export GH_TOKEN=$GITHUB_AUTH_TOKEN
-            NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
-            export NPM_TOKEN=$(curl -sf -XPOST \
-              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/tibber-aws" \
-              -H "Authorization: Bearer $NPM_ID_TOKEN" | jq -r '.token')
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
 
             yarn
             yarn release


### PR DESCRIPTION
Blocked and waiting for library support in semantic-release see https://github.com/semantic-release/npm/issues/1121 and https://github.com/semantic-release/npm/pull/1122/changes

Need to wait for upstream fix and them bump and test.