### PR TITLE
Revert back to static NPM token until semantic-release supports OIDC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
             - build
           context:
             - GITHUB
+            - NPM
           filters:
             branches:
               only:
@@ -61,10 +62,5 @@ jobs:
           name: Deploy Package
           command: |
             export GH_TOKEN=$GITHUB_AUTH_TOKEN
-            NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
-            export NPM_TOKEN=$(curl -sf -XPOST \
-              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/tibber-aws" \
-              -H "Authorization: Bearer $NPM_ID_TOKEN" | jq -r '.token')
-
             yarn
             yarn release


### PR DESCRIPTION
See https://github.com/tibber/tibber-aws/pull/486